### PR TITLE
feat(movies plugin): allows one to add movies through /movies endpoint

### DIFF
--- a/lib/plugins/features/movies/controller.js
+++ b/lib/plugins/features/movies/controller.js
@@ -1,0 +1,10 @@
+'use strict';
+
+const Movie = require('../../../models/movie');
+
+exports.create = (payload) => {
+  return new Movie().save(payload)
+  .then((movie) => {
+    return new Movie({ id: movie.id }).fetch();
+  });
+};

--- a/lib/plugins/features/movies/index.js
+++ b/lib/plugins/features/movies/index.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const Controller     = require('./controller');
+const MovieValidator = require('../../../validators/movie');
+
+exports.register = (server, options, next) => {
+
+  server.route([{
+    method: 'POST',
+    path: '/movies',
+    config: {
+      handler: (request, reply) => {
+        reply(Controller.create(request.payload));
+      },
+      validate: {
+        payload: MovieValidator
+      }
+    }
+  }]);
+
+  next();
+
+};
+
+exports.register.attributes = {
+  name: 'movies'
+};

--- a/lib/server.js
+++ b/lib/server.js
@@ -13,7 +13,12 @@ const server = new Hapi.Server({
 server.connection({ port: Config.PORT });
 
 server.register([
-  require('hapi-bookshelf-serializer')
+  require('hapi-bookshelf-serializer'),
+  {
+    register: require('hapi-format-error'),
+    options: { joiStatusCode: 422 }
+  },
+  require('./plugins/features/movies')
 ], (err) => {
   /* istanbul ignore if */
   if (err) {

--- a/lib/validators/movie.js
+++ b/lib/validators/movie.js
@@ -1,0 +1,8 @@
+'use strict';
+
+const Joi = require('joi');
+
+module.exports = Joi.object().keys({
+  title: Joi.string().min(1).max(255).required(),
+  release_year: Joi.number().min(1878).max(9999).optional()
+});

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1431,6 +1431,11 @@
         }
       }
     },
+    "hapi-format-error": {
+      "version": "1.0.0",
+      "from": "hapi-format-error@latest",
+      "resolved": "https://registry.npmjs.org/hapi-format-error/-/hapi-format-error-1.0.0.tgz"
+    },
     "has-ansi": {
       "version": "2.0.0",
       "from": "has-ansi@>=2.0.0 <3.0.0",
@@ -1606,6 +1611,11 @@
       "from": "isarray@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
     },
+    "isemail": {
+      "version": "2.1.2",
+      "from": "isemail@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/isemail/-/isemail-2.1.2.tgz"
+    },
     "isexe": {
       "version": "1.1.2",
       "from": "isexe@>=1.1.1 <2.0.0",
@@ -1652,6 +1662,18 @@
           "version": "0.3.0",
           "from": "mkdirp@0.3.0",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz"
+        }
+      }
+    },
+    "joi": {
+      "version": "8.1.1",
+      "from": "joi@latest",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-8.1.1.tgz",
+      "dependencies": {
+        "hoek": {
+          "version": "4.0.0",
+          "from": "hoek@>=4.0.0 <5.0.0",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.0.0.tgz"
         }
       }
     },
@@ -1965,6 +1987,11 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.2.0.tgz"
         }
       }
+    },
+    "moment": {
+      "version": "2.13.0",
+      "from": "moment@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.13.0.tgz"
     },
     "ms": {
       "version": "0.7.1",
@@ -2400,6 +2427,18 @@
       "version": "0.0.2",
       "from": "to-iso-string@0.0.2",
       "resolved": "https://registry.npmjs.org/to-iso-string/-/to-iso-string-0.0.2.tgz"
+    },
+    "topo": {
+      "version": "2.0.1",
+      "from": "topo@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/topo/-/topo-2.0.1.tgz",
+      "dependencies": {
+        "hoek": {
+          "version": "4.0.0",
+          "from": "hoek@4.x.x",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.0.0.tgz"
+        }
+      }
     },
     "touch": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,8 @@
     "bookshelf": "^0.9.5",
     "hapi": "^13.4.1",
     "hapi-bookshelf-serializer": "^2.1.0",
+    "hapi-format-error": "^1.0.0",
+    "joi": "^8.1.1",
     "knex": "^0.11.4",
     "pg": "^4.5.5"
   }

--- a/test/plugins/features/movie/controller.test.js
+++ b/test/plugins/features/movie/controller.test.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const Controller = require('../../../../lib/plugins/features/movies/controller');
+const Movie      = require('../../../../lib/models/movie');
+
+describe('movie controller', () => {
+
+  describe('create', () => {
+
+    it('creates a movie', () => {
+      const payload = { title: 'WALL-E', release_year: 2016 };
+
+      return Controller.create(payload)
+      .then((movie) => {
+        expect(movie.get('title')).to.eql(payload.title);
+
+        return new Movie({ id: movie.id }).fetch();
+      })
+      .then((movie) => {
+        expect(movie.get('title')).to.eql(payload.title);
+        expect(movie.get('release_year')).to.eql(payload.release_year);
+      });
+    });
+
+  });
+
+});

--- a/test/plugins/features/movie/index.test.js
+++ b/test/plugins/features/movie/index.test.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const Movies = require('../../../../lib/server');
+
+describe('movies integration', () => {
+
+  describe('create', () => {
+
+    it('creates a movie', () => {
+      return Movies.inject({
+        url: '/movies',
+        method: 'POST',
+        payload: { title: 'Volver' }
+      })
+      .then((response) => {
+        expect(response.statusCode).to.eql(200);
+        expect(response.result.object).to.eql('movie');
+      });
+    });
+
+  });
+
+});

--- a/test/validators/movie.test.js
+++ b/test/validators/movie.test.js
@@ -1,0 +1,83 @@
+'use strict';
+
+const Joi = require('joi');
+
+const MovieValidator = require('../../lib/validators/movie');
+
+describe('movie validator', () => {
+
+  describe('title', () => {
+
+    it('is required', () => {
+      const payload = {};
+      const result = Joi.validate(payload, MovieValidator);
+
+      expect(result.error.details[0].path).to.eql('title');
+      expect(result.error.details[0].type).to.eql('any.required');
+    });
+
+    it('is not empty', () => {
+      const payload = { title: '' };
+      const result = Joi.validate(payload, MovieValidator);
+
+      expect(result.error.details[0].path).to.eql('title');
+      expect(result.error.details[0].type).to.eql('any.empty');
+    });
+
+    it('is less than 255 characters', () => {
+      const payload = { title: 'a'.repeat(260) };
+      const result = Joi.validate(payload, MovieValidator);
+
+      expect(result.error.details[0].path).to.eql('title');
+      expect(result.error.details[0].type).to.eql('string.max');
+    });
+
+  });
+
+  describe('release_year', () => {
+
+    it('is after 1878', () => {
+      const payload = {
+        title: 'foo',
+        release_year: 1800
+      };
+      const result = Joi.validate(payload, MovieValidator);
+
+      expect(result.error.details[0].path).to.eql('release_year');
+      expect(result.error.details[0].type).to.eql('number.min');
+    });
+
+    it('is limited to 4 digits', () => {
+      const payload = {
+        title: 'foo',
+        release_year: 12345
+      };
+      const result = Joi.validate(payload, MovieValidator);
+
+      expect(result.error.details[0].path).to.eql('release_year');
+      expect(result.error.details[0].type).to.eql('number.max');
+    });
+
+    it('is limited to 4 digits', () => {
+      const payload = {
+        title: 'foo',
+        release_year: 12345
+      };
+      const result = Joi.validate(payload, MovieValidator);
+
+      expect(result.error.details[0].path).to.eql('release_year');
+      expect(result.error.details[0].type).to.eql('number.max');
+    });
+
+    it('is optional', () => {
+      const payload = {
+        title: 'foo'
+      };
+      const result = Joi.validate(payload, MovieValidator);
+
+      expect(result.error).to.eql(null);
+    });
+
+  });
+
+});


### PR DESCRIPTION
What: Creates a /movies endpoint with plugin

Why: Allows us to populate the database with `Movie`'s that we can specify data for.

Details:

POST to /movies endpoint with 

```
{
  "title": "movie_title"
  "release_year": 2016 (optional)
}
```

Unit tests for correct result from database
Integration test for whole endpoing
